### PR TITLE
New FlatUTMGraph

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ ArchGDAL = "c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3"
 GeoStats = "dcc97b0b-8ce5-5539-9008-bb190f959ef6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MeshGraphs = "9c3b456d-075c-421b-b774-fb43dd44b54d"
-Proj4 = "9a7e659c-8ee8-5706-894e-f68f43bc57ea"
+Proj = "c94c279d-25a6-4763-9509-64d165bea63e"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]

--- a/scripts/baltyk.jl
+++ b/scripts/baltyk.jl
@@ -1,0 +1,15 @@
+using TerrainGraphs
+
+t = TerrainGraphs.load_tiff("resources/extended_baltyk.tif")
+tk = TerrainGraphs.kriging_nan(t)
+t2 = TerrainMap(tk.M, tk.x_min, tk.y_min, tk.Δx, tk.Δy, tk.nx, tk.ny)
+p = TerrainGraphs.RefinementParameters(20, -100, 100, 100)
+g = TerrainGraphs.FlatUTMGraph(
+    "EPSG:25837", t2,
+    -1500000, 61000,
+    6100000, 7661000,
+    1, 1,
+)
+export_step(g, step) = export_inp(g, "baltyk_$(step).inp")
+export_step(g, 0)
+TerrainGraphs.adapt_terrain!(g, p, 18; after_step = export_step)

--- a/scripts/valparaiso.jl
+++ b/scripts/valparaiso.jl
@@ -1,5 +1,4 @@
 using TerrainGraphs
-using MeshGraphs
 
 t = TerrainGraphs.load_tiff("resources/val.tif")
 tk = TerrainGraphs.kriging_nan(t)

--- a/src/TerrainGraphs.jl
+++ b/src/TerrainGraphs.jl
@@ -36,7 +36,10 @@ export
     real_elevation,
     index_to_point,
     point_to_index,
-    point_to_index_coords
+    point_to_index_coords,
+
+    # From MeshGraphs
+    export_inp
 
 include("terrain_map.jl")
 include("spherical_graphs/spherical_graphs.jl")

--- a/src/TerrainGraphs.jl
+++ b/src/TerrainGraphs.jl
@@ -10,6 +10,10 @@ export
     FlatSpec,
     initial_flat_graph,
 
+    # FlatUTMGraph
+    FlatUTMGraph,
+    FlatUTMSpec,
+
     # ShpereGraph
     SphereGraph,
     SphereSpec,
@@ -44,6 +48,7 @@ export
 include("terrain_map.jl")
 include("spherical_graphs/spherical_graphs.jl")
 include("flat_graphs/flat_graphs.jl")
+include("flat_utm_graphs/flat_utm_graphs.jl")
 include("utils.jl")
 include("adapt_terrain.jl")
 include("error_calculation.jl")

--- a/src/flat_graphs/flatgraph.jl
+++ b/src/flat_graphs/flatgraph.jl
@@ -1,4 +1,4 @@
-using Proj4
+using Proj
 
 # Type definition
 
@@ -7,20 +7,15 @@ struct FlatSpec <: AbstractSpec
     terrain_map::TerrainMap
 end
 
-function FlatSpec(proj4_code::String, terrain_map::TerrainMap)
-    trans = Proj4.Transformation("EPSG:4326", proj4_code)
+function FlatSpec(proj_code::String, terrain_map::TerrainMap)
+    trans = Proj.Transformation("EPSG:4326", proj_code, always_xy = true)
     FlatSpec(trans, terrain_map)
 end
 
 const FlatGraph = MeshGraph{FlatSpec}
 
-FlatGraph(proj, terrain_map::TerrainMap) =
-    MeshGraph(FlatSpec(proj, terrain_map))
-
-function FlatGraph(proj4_code::String, terrain_map::TerrainMap)
-    trans = Proj4.Transformation("EPSG:4326", proj4_code)
-    FlatGraph(trans, terrain_map)
-end
+FlatGraph(proj_code::String, terrain_map::TerrainMap) =
+    FlatGraph(FlatSpec(proj_code, terrain_map))
 
 terrain_map(g::FlatGraph) = spec(g).terrain_map
 
@@ -35,7 +30,7 @@ end
 
 function convert_proj(g::FlatGraph, coords::AbstractVector{<:Real})
     u, v, e = coords
-    x, y = spec(g).trans([v, u])        # This has to be reversed in Proj4
+    x, y = spec(g).trans([u, v])
     return [x, y, e]
 end
 

--- a/src/flat_utm_graphs/flat_utm_graphs.jl
+++ b/src/flat_utm_graphs/flat_utm_graphs.jl
@@ -1,0 +1,1 @@
+include("flatutmgraph.jl")

--- a/src/flat_utm_graphs/flatutmgraph.jl
+++ b/src/flat_utm_graphs/flatutmgraph.jl
@@ -1,0 +1,77 @@
+using Proj
+
+# Type definition
+struct FlatUTMSpec <: AbstractSpec
+    trans
+    terrain_map::TerrainMap
+end
+
+function FlatUTMSpec(proj4_code::String, terrain_map::TerrainMap)
+    trans = Proj.Transformation(proj4_code, "EPSG:4326", always_xy = true)
+    FlatUTMSpec(trans, terrain_map)
+end
+
+const FlatUTMGraph = MeshGraph{FlatUTMSpec}
+
+FlatUTMGraph(proj4_code::String, terrain_map::TerrainMap) =
+    FlatUTMGraph(FlatUTMSpec(proj4_code, terrain_map))
+
+terrain_map(g::FlatUTMGraph) = spec(g).terrain_map
+
+# Type adjusting
+function new_coords_flat(g::FlatUTMGraph, v1::Integer, v2::Integer)
+    xy1 = xyz(g, v1)[1:2]
+    xy2 = xyz(g, v2)[1:2]
+    new_x, new_y = mean([xy1, xy2])
+    _, _, elev = MeshGraphs.convert(g, [new_x, new_y])
+    return [new_x, new_y, elev]
+end
+
+function convert_proj(g::FlatUTMGraph, coords::AbstractVector{<:Real})
+    u, v = spec(g).trans(coords)
+    elev = real_elevation(spec(g).terrain_map, u, v)
+    return [u, v, elev]
+end
+
+function distance_flat_xy(g::FlatUTMGraph, v1::Integer, v2::Integer)
+    xy1 = xyz(g, v1)[1:2]
+    xy2 = xyz(g, v2)[1:2]
+    return norm(xy2 - xy1)
+end
+
+MeshGraphs.add_vertex_strategy(_::FlatUTMGraph) = USE_XYZ
+
+MeshGraphs.convert(g::FlatUTMGraph, coords::AbstractVector{<:Real}) =
+    convert_proj(g, coords)
+
+MeshGraphs.distance(g::FlatUTMGraph, v1::Integer, v2::Integer) =
+    distance_flat_xy(g, v1, v2)
+
+MeshGraphs.new_vertex_coords(g::FlatUTMGraph, v1::Integer, v2::Integer) =
+    new_coords_flat(g, v1, v2)
+
+function local_get_elevation(g::FlatUTMGraph, i::Integer)
+    u, v = uv(g, i)
+    return real_elevation(spec(g).terrain_map, u, v)
+end
+
+
+# Initial graphs
+function FlatUTMGraph(proj4_code::String, t::TerrainMap, x_min, x_max, y_min, y_max, n_elem_x, n_elem_y)
+    g = rectangle_graph(
+        FlatUTMSpec(proj4_code, t),
+        x_min,
+        x_max,
+        y_min,
+        y_max,
+        n_elem_x,
+        n_elem_y,
+    )
+
+    for i in normal_vertices(g)
+        elev = local_get_elevation(g, i)
+        set_elevation!(g, i, elev)
+    end
+
+    return g
+end


### PR DESCRIPTION
Hi, Paweł.

I have made these commits to generate the mesh with the grid aligned to the UTM coordinates.

The three commits are entirely unrelated:
- The first one exports the `export_inp` function from MeshGraphs. It's more usable.
- The second one is changing `Proj4.jl` to `Proj.jl` as its readme says (https://github.com/JuliaGeo/Proj.jl/blob/master/README.md)
- Finally, add all the code for the aligned UTM mesh generation.

Feel free to separate them.